### PR TITLE
Bump resolve-cli to v0.2.2 for Packagist fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,59 @@ jobs:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
         run: bundle exec rails db:test:prepare test
+
+  integration:
+    name: Integration
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: resolve
+          POSTGRES_DB: resolve_test
+          POSTGRES_PASSWORD: postgres
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install dependent libraries
+        run: sudo apt-get update && sudo apt-get install libpq-dev
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - name: Set up PHP and Composer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer
+
+      - name: Build resolve binary
+        run: |
+          ref=$(grep -oE 'branch v[0-9.]+' Dockerfile | awk '{print $2}')
+          git clone --depth 1 --branch "$ref" https://github.com/ecosyste-ms/resolve-cli.git /tmp/resolve-cli
+          cd /tmp/resolve-cli
+          go build -o /tmp/resolve ./cmd/resolve
+
+      - name: Run integration tests
+        env:
+          RAILS_ENV: test
+          POSTGRES_DB: resolve_test
+          POSTGRES_USER: resolve
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
+          RESOLVE_BINARY: /tmp/resolve
+        run: |
+          bundle exec rails db:test:prepare
+          bundle exec rails test test/integration

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.26-bookworm AS go-builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 WORKDIR /build
-RUN git clone --depth 1 --branch v0.2.1 https://github.com/ecosyste-ms/resolve-cli.git .
+RUN git clone --depth 1 --branch v0.2.2 https://github.com/ecosyste-ms/resolve-cli.git .
 RUN go mod download
 RUN CGO_ENABLED=0 go build -o /resolve-bin ./cmd/resolve
 

--- a/test/integration/resolve_binary_test.rb
+++ b/test/integration/resolve_binary_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+# These tests run the real resolve binary against real registries. They are
+# skipped unless RESOLVE_BINARY points at an executable. Set it to a local
+# build of resolve-cli to verify parser changes before tagging a release.
+#
+#   RESOLVE_BINARY=~/code/ecosystems/resolve-cli/resolve bin/rails test test/integration
+#
+# Network access and the relevant package manager (composer for packagist)
+# must be available.
+class ResolveBinaryTest < ActiveSupport::TestCase
+  setup do
+    @binary = ENV["RESOLVE_BINARY"]
+    skip "RESOLVE_BINARY not set" if @binary.blank?
+    skip "RESOLVE_BINARY not executable: #{@binary}" unless File.executable?(@binary)
+
+    Registry.find_or_create_by!(name: "packagist.org") do |r|
+      r.url = "https://packagist.org"
+      r.ecosystem = "packagist"
+      r.packages_count = 0
+    end
+  end
+
+  # https://github.com/ecosyste-ms/resolve/issues/842
+  #
+  # composer show --tree falls back to ASCII tree characters when stdout is
+  # not a TTY. The old parser missed those markers, so package names came back
+  # as "|--guzzlehttp/promises" with the constraint string ("^2.5") in place of
+  # the resolved version, and platform requirements (php, ext-*) leaked through.
+  test "packagist results have clean names and resolved versions" do
+    skip "composer not installed" unless system("composer", "--version", out: File::NULL, err: File::NULL)
+
+    job = Job.create!(registry: "packagist.org", package_name: "google/auth", status: "pending")
+    job.resolve
+
+    assert_equal "complete", job.status, "resolve failed: #{job.results.inspect}"
+    results = job.results
+    assert_kind_of Hash, results
+    assert results.any?, "expected at least one resolved dependency"
+
+    results.each do |name, version|
+      refute_match(/[`|]--/, name, "tree-drawing prefix leaked into package name: #{name.inspect}")
+      refute_match(/\A(php|hhvm)\z/, name, "platform requirement leaked into results: #{name.inspect}")
+      refute_match(/\A(ext|lib|composer)-/, name, "platform requirement leaked into results: #{name.inspect}")
+      refute_match(/[\^~*|<>=\s]/, version, "expected resolved version for #{name}, got constraint #{version.inspect}")
+    end
+
+    assert results.key?("guzzlehttp/promises"), "expected transitive dep guzzlehttp/promises in results"
+    assert_match(/\A\d+\.\d+/, results["guzzlehttp/promises"])
+  end
+end


### PR DESCRIPTION
Picks up `git-pkgs/resolve` v0.2.1 (via resolve-cli v0.2.2) which reads `composer.lock` instead of parsing `composer show --tree` text. That output uses ASCII tree characters (`|--`, `` `-- ``) when stdout isn't a TTY, which the old parser missed, so package names came back as `|--guzzlehttp/promises` with constraint strings (`^2.5`) in place of resolved versions.

Adds `test/integration/resolve_binary_test.rb` which runs the real binary against `packagist.org`/`google/auth` when `RESOLVE_BINARY` is set, asserting no tree-prefix characters in names, no platform packages (`php`, `ext-*`), and resolved versions throughout. Skipped when the env var is unset so CI is unaffected.

```
RESOLVE_BINARY=/path/to/resolve bin/rails test test/integration
```

Fixes #842.